### PR TITLE
fix(renovate): disable updates.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,23 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>kubewarden/github-actions//renovate-config/policies"
   ],
   "packageRules": [
     {
-      "description": "Update GitHub Actions",
-      "matchManagers": ["github-actions"],
-      "groupName": "github-actions",
-      "groupSlug": "github-actions"
+      "description": "Disable all non-GitHub-Action updates",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "excludePackageNames": [],
+      "enabled": false
+    },
+    {
+      "description": "Enable updates for GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
## Description

This policy should update the its packages together with Kyverno. This requires manual work. Therefore, this commit disable the packages updates while the automatic Kyverno update is not possible. The new configuration keep the automatic update only for github actions.

Fix https://github.com/kubewarden/kyverno-dsl-policy/issues/83
